### PR TITLE
fixing clear and showAllCharacters buttons

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -148,6 +148,7 @@ function limpiar(){
     document.querySelector(".cards").style.display="flex";
     document.querySelector(".noSearch").style.display="none";
     document.getElementById("searchInp").value="";
+    showAllCharacters(data.results);
 }
 
 document.getElementById("allCharacts").addEventListener("click", showAll);
@@ -156,6 +157,7 @@ function showAll(){
     document.querySelector(".cards").style.display="none";
     document.querySelector(".noSearch").style.display="none";
     document.getElementById("searchInp").value="";
+    showAllCharacters(data.results);
 }
 
   //  export const ordenA = (data) => ordenAlf(data);


### PR DESCRIPTION
Mandamos llamar nuestra función showAllCharacters en cada uno de los botones "clear" y "show all characters" para limpiar el filtro de la búsqueda previamente hecha por el usuario y redirigirlo a la página de inicio.