### PR TITLE
removing orderAlf tests comments

### DIFF
--- a/test/data.spec.js
+++ b/test/data.spec.js
@@ -1,4 +1,4 @@
-import { filterData, /*orderAlf*/ } from '../src/data.js';
+import { filterData, orderAlf } from '../src/data.js';
 
 const mockCharacters=[{"name": "Rick Sanchez"}, {"name": "Morty Smith"}, {"name": "Summer Smith"}]
 describe('filterData', () => 


### PR DESCRIPTION
- Olvidé des-comentar algunas partes de los tests de la función orderAlf, pero en este pull request ya no está nada comentado.
- Los 7 tests de filterData aún funcionan correctamente.
<img width="1440" alt="212947358-1c2216f9-c83b-4d36-9afd-58f07afcc717" src="https://user-images.githubusercontent.com/114522807/212949975-b1ee4493-6c11-4117-9b76-de8cd35bbdde.png">
